### PR TITLE
DS-1440 fix: Change Twitter to X and import titles properly.

### DIFF
--- a/config/install/migrate_plus.migration.y_lb_demo_block_social_links.yml
+++ b/config/install/migrate_plus.migration.y_lb_demo_block_social_links.yml
@@ -21,19 +21,29 @@ source:
       uuid: '0900856e-0550-4b6a-b58f-71133638caab'
       links:
         - uri: 'https://facebook.com'
-          title: 'Facebook'
+          options:
+            attributes:
+              title: 'Facebook'
 
         - uri: 'https://instagram.com'
-          title: 'Instagram'
+          options:
+            attributes:
+              title: 'Instagram'
 
         - uri: 'https://linkedin.com'
-          title: 'Linkedin'
+          options:
+            attributes:
+              title: 'Linkedin'
 
         - uri: 'https://youtube.com'
-          title: 'Youtube'
+          options:
+            attributes:
+              title: 'Youtube'
 
-        - uri: 'https://twitter.com'
-          title: 'Twitter'
+        - uri: 'https://x.com'
+          options:
+            attributes:
+              title: 'X'
   ids:
     id:
       type: integer


### PR DESCRIPTION
After adding the icon, we need to change the imported URL so that the Twitter icon changes to X.

Also, in the process I found that the titles of the URLs were not importing properly, as we don't store them at the field title, but the attribute title. This resolves that issue, so the proper titles will appear for accessibility.

![SCR-20240703-ihvm](https://github.com/YCloudYUSA/y_lb_demo_content/assets/238201/15b36ec9-af54-46cc-8a0c-737a9c729e9b)
